### PR TITLE
Fixes for 429 error and for potential code execution bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ bin: $(BIN_PYTHON)
 
 deploy: deploy-client 
 deploy-all: deploy-client 
-deploy-client: deploy-scripts 
+deploy-client: deploy-scripts deploy-libs
 
 include $(TOP_DIR)/tools/Makefile.common.rules


### PR DESCRIPTION
Hint: what happens if someone passes this in for a SRR id in the interface:

```
SRR'; date > /tmp/abcd'
```